### PR TITLE
Set partner status to error if branch is out of date

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -71,7 +71,7 @@ export default function(app) {
           return syncPR(pullRequest, ['meta']);
         case 'opened':
         case 'synchronize':
-          return syncPR(pullRequest, ['commits', 'state']);
+          return syncPR(pullRequest, ['commits', 'state', 'statuses']);
       }
     },
   );

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,32 +11,48 @@ import {getGithubId, request} from './github.js';
 import {getRepoNames} from './relationships.js';
 import {generateKeyFromPR, throttleWebhook} from './utils.js';
 
-async function syncOpenPRs() {
+/**
+ * @typedef {{
+ *   number: number,
+ *   repoName: string,
+ * }} PROptType
+ */
+
+/**
+ * @returns {PROptType[]}
+ */
+async function getOpenPRs(repoName) {
+  const pullRequests = await request('GET /repos/:repoName/pulls', {
+    repoName,
+  }).then(res => res.data || []);
+
+  return pullRequests.map(({number}) => ({number, repoName}));
+}
+
+async function initialize() {
   for (const repoName of getRepoNames()) {
-    const pullRequests = await request('GET /repos/:repoName/pulls', {
-      repoName,
-    }).then(res => res.data || []);
+    const pullRequests = await getOpenPRs(repoName);
 
     for (const pullRequest of pullRequests) {
-      const {number} = pullRequest;
-      const cacheKey = generateKeyFromPR({number, repoName});
+      // since this runs on startup, if it already has a cached partner,
+      // we can assume it's already been synced; it's because of this
+      // mechanism that this runs serially instead of in parallel
+      if (cache.get(`partner-prs.${generateKeyFromPR(pullRequest)}`)) continue;
 
-      // if it already has a cached partner, we can assume it's
-      // already been synced
-      if (!cache.get(`partner-prs.${cacheKey}`)) {
-        try {
-          await syncPR({number, repoName});
-        } catch (error) {
-          console.error(`error syncing ${repoName}#${number}`);
-          console.error(error);
-        }
+      try {
+        await syncPR(pullRequest);
+      } catch (error) {
+        console.error(
+          `error syncing ${pullRequest.repoName}#${pullRequest.number}:`,
+        );
+        console.error(error);
       }
     }
   }
 }
 
 export default function(app) {
-  syncOpenPRs().catch(console.error);
+  initialize().catch(console.error);
 
   app.on(['pull_request.unlabeled'], async ({payload}) => {
     if (payload.label.name !== 'disable-sync') return;
@@ -75,6 +91,18 @@ export default function(app) {
       }
     },
   );
+
+  // update statuses since push to master will make open PRs
+  // out of date
+  app.on('push', async ({payload}) => {
+    if (payload.ref !== 'refs/heads/master') return;
+
+    const pullRequests = await getOpenPRs(payload.repository.full_name);
+
+    return Promise.all(
+      pullRequests.map(pullRequest => syncPR(pullRequest, ['statuses'])),
+    );
+  });
 
   app.on('status', async ({payload}) => {
     const isInMaster = payload.branches.some(

--- a/lib/sync/commit-status.js
+++ b/lib/sync/commit-status.js
@@ -24,15 +24,27 @@ import {parallel} from '../utils.js';
  * these aren't uppercase because github v3 api uses lowercase,
  * while v4 graphql api uses uppercase
  * @typedef {'error' | 'pending' | 'failure' | 'success'} CommitStatusStateType
+ *
+ * @typedef {'CONFLICTING' | 'MERGEABLE' | 'UNKNOWN'} MergeableStateType
  */
 
 /**
- * @param {PROptType} pullRequest
- * @returns {Promise<CommitStatusType[]>}
+ * @typedef {{
+ *   branchState: 'ahead' | 'behind',
+ *   latestCommitSha: string,
+ *   mergeable: MergeableStateType,
+ *   statuses: CommitStatusType[],
+ * }} PRInfoType
  */
-async function getLatestCommit(pullRequest) {
-  return getPRFromNumber(
+/**
+ * @param {PROptType} pullRequest
+ * @returns {Promise<PRInfoType>}
+ */
+async function getPRInfo(pullRequest) {
+  const {repoName} = pullRequest;
+  const res = await getPRFromNumber(
     `{
+      baseRefName
       commits(last: 1) {
         nodes {
           commit {
@@ -43,13 +55,39 @@ async function getLatestCommit(pullRequest) {
           }
         }
       }
+      headRefName
+      headRepositoryOwner {login}
+      isCrossRepository
+      mergeable
     }`,
     pullRequest,
-    'repository.pullRequest.commits.nodes.0.commit',
-  ).then(commit => ({
-    sha: commit.oid,
-    statuses: get(commit, 'status.contexts') || [],
-  }));
+    'repository.pullRequest',
+  );
+  const {
+    baseRefName,
+    headRefName,
+    headRepositoryOwner,
+    isCrossRepository,
+    mergeable,
+  } = res;
+  const latestCommit = get(res, 'commits.nodes.0.commit');
+  const branchState = await request(
+    'GET /repos/:repoName/compare/:baseRef...:headRef',
+    {
+      repoName,
+      baseRef: baseRefName,
+      headRef: isCrossRepository
+        ? `${headRepositoryOwner.login}:${headRefName}`
+        : headRefName,
+    },
+  ).then(res => res.data.status);
+
+  return {
+    branchState,
+    latestCommitSha: latestCommit.oid,
+    mergeable,
+    statuses: get(latestCommit, 'status.contexts') || [],
+  };
 }
 
 /**
@@ -70,7 +108,7 @@ function filterSyncStatus(statuses) {
 }
 
 /**
- * Removes sync status from array of statuses
+ * Finds sync status from array of statuses
  * @param {CommitStatusType[]} statuses
  * @returns {CommitStatusStateType | void}
  */
@@ -85,16 +123,22 @@ function getSyncState(statuses) {
 }
 
 /**
- * @param {CommitStatusType[]} statuses
+ * @param {PRInfoType} prInfo
  * @returns {CommitStatusStateType}
  */
-function getGroupedState(statuses) {
+export function getGroupedState(prInfo) {
+  const {branchState, mergeable, statuses} = prInfo;
   const states = new Set(
     filterSyncStatus(statuses).map(status => status.state),
   );
   let result;
 
-  if (states.has('ERROR')) {
+  if (
+    states.has('ERROR') ||
+    // TODO: add description to status explaining why it's an error
+    mergeable !== 'MERGEABLE' ||
+    branchState !== 'ahead'
+  ) {
     result = 'error';
   } else if (states.has('FAILURE')) {
     result = 'failure';
@@ -113,49 +157,42 @@ function getGroupedState(statuses) {
  * @returns {Promise<void>}
  */
 export async function syncStatuses(primaryPR, secondaryPR) {
-  const [
-    {sha: primarySha, statuses: primaryStatuses},
-    {sha: secondarySha, statuses: secondaryStatuses},
-  ] = await Promise.all([
-    getLatestCommit(primaryPR),
-    getLatestCommit(secondaryPR),
+  const [primaryInfo, secondaryInfo] = await Promise.all([
+    getPRInfo(primaryPR),
+    getPRInfo(secondaryPR),
   ]);
 
   await parallel([
     // sync primary pr
     async () => {
-      if (filterSyncStatus(secondaryStatuses).length) {
-        const groupedState = getGroupedState(secondaryStatuses);
-        const currentState = getSyncState(primaryStatuses);
+      const groupedState = getGroupedState(secondaryInfo);
+      const currentState = getSyncState(primaryInfo.statuses);
 
-        if (currentState !== groupedState.toUpperCase()) {
-          return request('POST /repos/:repoName/statuses/:sha', {
-            repoName: primaryPR.repoName,
-            sha: primarySha,
-            data: {
-              context: 'probot/monorepo-sync/secondary-pr',
-              state: groupedState,
-            },
-          });
-        }
+      if (currentState !== groupedState.toUpperCase()) {
+        return request('POST /repos/:repoName/statuses/:sha', {
+          repoName: primaryPR.repoName,
+          sha: primaryInfo.latestCommitSha,
+          data: {
+            context: 'probot/monorepo-sync/secondary-pr',
+            state: groupedState,
+          },
+        });
       }
     },
     // sync secondary pr
     async () => {
-      if (filterSyncStatus(primaryStatuses).length) {
-        const groupedState = getGroupedState(primaryStatuses);
-        const currentState = getSyncState(secondaryStatuses);
+      const groupedState = getGroupedState(primaryInfo);
+      const currentState = getSyncState(secondaryInfo.statuses);
 
-        if (currentState !== groupedState.toUpperCase()) {
-          return request('POST /repos/:repoName/statuses/:sha', {
-            repoName: secondaryPR.repoName,
-            sha: secondarySha,
-            data: {
-              context: 'probot/monorepo-sync/primary-pr',
-              state: groupedState,
-            },
-          });
-        }
+      if (currentState !== groupedState.toUpperCase()) {
+        return request('POST /repos/:repoName/statuses/:sha', {
+          repoName: secondaryPR.repoName,
+          sha: secondaryInfo.latestCommitSha,
+          data: {
+            context: 'probot/monorepo-sync/primary-pr',
+            state: groupedState,
+          },
+        });
       }
     },
   ]);

--- a/lib/sync/commit-status.test.js
+++ b/lib/sync/commit-status.test.js
@@ -1,0 +1,118 @@
+/** Copyright (c) 2019 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const esmRequire = require('esm')(module);
+const {getGroupedState} = esmRequire('./commit-status.js');
+
+test('getGroupedState', () => {
+  // error
+  expect(
+    getGroupedState({
+      branchState: 'ahead',
+      mergeable: 'MERGEABLE',
+      statuses: [
+        {
+          context: 'foo',
+          state: 'ERROR',
+        },
+        {
+          context: 'bar',
+          state: 'SUCCESS',
+        },
+      ],
+    }),
+  ).toBe('error');
+  expect(
+    getGroupedState({
+      branchState: 'ahead',
+      mergeable: 'CONFLICTING',
+      statuses: [
+        {
+          context: 'foo',
+          state: 'SUCCESS',
+        },
+      ],
+    }),
+  ).toBe('error');
+  expect(
+    getGroupedState({
+      branchState: 'ahead',
+      mergeable: 'UNKNOWN',
+      statuses: [
+        {
+          context: 'foo',
+          state: 'SUCCESS',
+        },
+      ],
+    }),
+  ).toBe('error');
+  expect(
+    getGroupedState({
+      branchState: 'behind',
+      mergeable: 'MERGEABLE',
+      statuses: [
+        {
+          context: 'bar',
+          state: 'SUCCESS',
+        },
+      ],
+    }),
+  ).toBe('error');
+
+  // failure
+  expect(
+    getGroupedState({
+      branchState: 'ahead',
+      mergeable: 'MERGEABLE',
+      statuses: [
+        {
+          context: 'foo',
+          state: 'FAILURE',
+        },
+        {
+          context: 'bar',
+          state: 'SUCCESS',
+        },
+      ],
+    }),
+  ).toBe('failure');
+
+  // pending
+  expect(
+    getGroupedState({
+      branchState: 'ahead',
+      mergeable: 'MERGEABLE',
+      statuses: [
+        {
+          context: 'foo',
+          state: 'PENDING',
+        },
+        {
+          context: 'bar',
+          state: 'SUCCESS',
+        },
+      ],
+    }),
+  ).toBe('pending');
+
+  // success
+  expect(
+    getGroupedState({
+      branchState: 'ahead',
+      mergeable: 'MERGEABLE',
+      statuses: [
+        {
+          context: 'foo',
+          state: 'SUCCESS',
+        },
+        {
+          context: 'bar',
+          state: 'SUCCESS',
+        },
+      ],
+    }),
+  ).toBe('success');
+});


### PR DESCRIPTION
Fixes #14

If the partner PR head branch isn't `ahead` of its base branch, or if it's not `MERGEABLE`, the status will report as an error.

This will prevent PRs from being merged while its partner is out of date (causing the merge sync to fail)