### PR TITLE
Use user token for all REST requests

### DIFF
--- a/lib/github.js
+++ b/lib/github.js
@@ -95,7 +95,7 @@ async function authedRequest(url, props, repoName) {
     // due to limitations of github app accounts (e.g. can't reference
     // PRs/issues from comments)
     if (
-      (url.startsWith('GET') || url === 'POST /graphql') &&
+      url === 'POST /graphql' &&
       repoName &&
       repoNamesToInstallIDs.has(repoName)
     ) {


### PR DESCRIPTION
Given that all the `Bad credentials` errors were from REST requests, this is an attempt to fix the auth issues by never authenticating as the github app for REST. I haven't pinpointed the exact cause of the auth issues, but I'm hoping this will fix them based on that reasoning