### PR TITLE
Fix rebase sync

### DIFF
--- a/lib/__fixtures__/commit.json
+++ b/lib/__fixtures__/commit.json
@@ -1,0 +1,95 @@
+{
+  "url": "https://api.github.com/repos/octocat/Hello-World/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+  "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+  "node_id": "MDY6Q29tbWl0NmRjYjA5YjViNTc4NzVmMzM0ZjYxYWViZWQ2OTVlMmU0MTkzZGI1ZQ==",
+  "html_url": "https://github.com/octocat/Hello-World/commit/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+  "comments_url": "https://api.github.com/repos/octocat/Hello-World/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e/comments",
+  "commit": {
+    "url": "https://api.github.com/repos/octocat/Hello-World/git/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+    "author": {
+      "name": "Monalisa Octocat",
+      "email": "support@github.com",
+      "date": "2011-04-14T16:00:49Z"
+    },
+    "committer": {
+      "name": "Monalisa Octocat",
+      "email": "support@github.com",
+      "date": "2011-04-14T16:00:49Z"
+    },
+    "message": "Fix all the bugs",
+    "tree": {
+      "url": "https://api.github.com/repos/octocat/Hello-World/tree/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+      "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e"
+    },
+    "comment_count": 0,
+    "verification": {
+      "verified": false,
+      "reason": "unsigned",
+      "signature": null,
+      "payload": null
+    }
+  },
+  "author": {
+    "login": "octocat",
+    "id": 1,
+    "node_id": "MDQ6VXNlcjE=",
+    "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/octocat",
+    "html_url": "https://github.com/octocat",
+    "followers_url": "https://api.github.com/users/octocat/followers",
+    "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+    "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+    "organizations_url": "https://api.github.com/users/octocat/orgs",
+    "repos_url": "https://api.github.com/users/octocat/repos",
+    "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/octocat/received_events",
+    "type": "User",
+    "site_admin": false
+  },
+  "committer": {
+    "login": "octocat",
+    "id": 1,
+    "node_id": "MDQ6VXNlcjE=",
+    "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/octocat",
+    "html_url": "https://github.com/octocat",
+    "followers_url": "https://api.github.com/users/octocat/followers",
+    "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+    "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+    "organizations_url": "https://api.github.com/users/octocat/orgs",
+    "repos_url": "https://api.github.com/users/octocat/repos",
+    "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/octocat/received_events",
+    "type": "User",
+    "site_admin": false
+  },
+  "parents": [
+    {
+      "url": "https://api.github.com/repos/octocat/Hello-World/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+      "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e"
+    }
+  ],
+  "stats": {
+    "additions": 104,
+    "deletions": 4,
+    "total": 108
+  },
+  "files": [
+    {
+      "filename": "file1.txt",
+      "additions": 10,
+      "deletions": 2,
+      "changes": 12,
+      "status": "modified",
+      "raw_url": "https://github.com/octocat/Hello-World/raw/7ca483543807a51b6079e54ac4cc392bc29ae284/file1.txt",
+      "blob_url": "https://github.com/octocat/Hello-World/blob/7ca483543807a51b6079e54ac4cc392bc29ae284/file1.txt",
+      "patch": "@@ -29,7 +29,7 @@\n....."
+    }
+  ]
+}

--- a/lib/__fixtures__/ref.json
+++ b/lib/__fixtures__/ref.json
@@ -1,0 +1,10 @@
+{
+  "ref": "refs/heads/featureA",
+  "node_id": "MDM6UmVmcmVmcy9oZWFkcy9mZWF0dXJlQQ==",
+  "url": "https://api.github.com/repos/octocat/Hello-World/git/refs/heads/featureA",
+  "object": {
+    "type": "commit",
+    "sha": "aa218f56b14c9653891f9e74264a383fa43fefbd",
+    "url": "https://api.github.com/repos/octocat/Hello-World/git/commits/aa218f56b14c9653891f9e74264a383fa43fefbd"
+  }
+}

--- a/lib/github/__mocks__/utils.js
+++ b/lib/github/__mocks__/utils.js
@@ -1,0 +1,24 @@
+/** Copyright (c) 2019 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import Octokit from '@octokit/rest';
+const octokit = new Octokit();
+
+export async function authedRequest(url, props) {
+  return octokit.request(url, props).catch(error => {
+    Object.assign(error, {
+      authType: 'mocked',
+      requestProps: props,
+      requestUrl: url,
+    });
+
+    throw error;
+  });
+}
+
+export async function getGithubId() {
+  return 0;
+}

--- a/lib/github/utils.js
+++ b/lib/github/utils.js
@@ -99,7 +99,7 @@ export async function getGithubId() {
  * wrapper for actual initializer; caches returned promise
  * @returns {InitReturn}
  */
-export async function initialize() {
+async function initialize() {
   if (!INIT_PROMISE) {
     INIT_PROMISE = _initialize().catch(console.error);
   }

--- a/lib/sync/commits.js
+++ b/lib/sync/commits.js
@@ -300,6 +300,26 @@ function cachePartnerCommits(opts) {
   );
 }
 
+function commitModifiesSubPath(commit, subPath) {
+  for (const file of commit.files) {
+    if (file.filename.startsWith(subPath)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function commitModifiesAboveSubPath(commit, subPath) {
+  for (const file of commit.files) {
+    if (!file.filename.startsWith(subPath)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 /**
  * @param {{
  *   commitSha: string,
@@ -390,6 +410,50 @@ async function getPartnerCommitSha(opts) {
         break;
       }
     }
+  }
+}
+
+/**
+ * @param {{
+ *   commitSha: string,
+ *   fallbackSha: string,
+ *   partnerBranch: string,
+ *   partnerRepoName: string,
+ *   repoName: string,
+ *   subPath: string,
+ * }} opts
+ * @returns {Promise<string | void>}
+ */
+export async function getPartnerRebaseSha(opts) {
+  let commit = await request('GET /repos/:repoName/commits/:sha', {
+    repoName: opts.repoName,
+    sha: opts.commitSha,
+  }).then(res => res.data);
+
+  if (opts.subPath) {
+    // walk parent commits until a syncable commit is found
+    while (commit.parents.length) {
+      if (commitModifiesSubPath(commit, opts.subPath)) {
+        break;
+      } else {
+        commit = await request('GET /repos/:repoName/commits/:sha', {
+          repoName: opts.repoName,
+          sha: commit.parents[0].sha,
+        }).then(res => res.data);
+      }
+    }
+  }
+
+  const partnerCommitSha = await getPartnerCommitSha({
+    ...pick(opts, ['partnerBranch', 'partnerRepoName', 'repoName']),
+    commitSha: commit.sha,
+    historyWindow: 10,
+  });
+
+  if (partnerCommitSha) {
+    return partnerCommitSha;
+  } else {
+    return opts.fallbackSha;
   }
 }
 
@@ -811,7 +875,20 @@ export async function syncCommits(primaryPR, secondaryPR) {
       ? secondaryPR.repoName
       : primaryPR.repoName;
     const hasCommonCommit = typeof lastCommonSourceIndex === 'number';
-    const copyOpts = {
+    const targetBaseBranch = targetPRInfo.base.ref;
+    const sourceSubPath = getChildPath(sourceBaseRepoName, targetBaseRepoName);
+    const targetCommitSha = hasCommonCommit
+      ? targetCommits[lastCommonTargetIndex].sha
+      : await getPartnerRebaseSha({
+          commitSha: sourceCommits[0]._.parents[0].sha,
+          fallbackSha: targetCommits[0]._.parents[0].sha,
+          partnerBranch: targetBaseBranch,
+          partnerRepoName: targetBaseRepoName,
+          repoName: sourceBaseRepoName,
+          subPath: sourceSubPath,
+        });
+
+    await copyCommits({
       forcePush: state.hasConflict,
       includeTraceSha: true,
       stripMeta: true,
@@ -821,19 +898,15 @@ export async function syncCommits(primaryPR, secondaryPR) {
         commits: sourceCommits,
         lastCommonIndex: hasCommonCommit ? lastCommonSourceIndex : -1,
         repoName: sourceRepoName,
-        subPath: getChildPath(sourceBaseRepoName, targetBaseRepoName),
+        subPath: sourceSubPath,
       },
       target: {
-        baseBranch: targetPRInfo.base.ref,
+        baseBranch: targetBaseBranch,
         branch: targetPRInfo.head.ref,
-        commitSha: hasCommonCommit
-          ? targetCommits[lastCommonTargetIndex].sha
-          : targetCommits[0]._.parents[0].sha,
+        commitSha: targetCommitSha,
         repoName: targetRepoName,
         subPath: getChildPath(targetBaseRepoName, sourceBaseRepoName),
       },
-    };
-
-    await copyCommits(copyOpts);
+    });
   }
 }

--- a/lib/sync/commits.js
+++ b/lib/sync/commits.js
@@ -328,7 +328,7 @@ function commitModifiesAboveSubPath(commit, subPath) {
  *   repoName: string,
  *   historyWindow?: number,
  * }} opts
- * @returns {Promise<string>}
+ * @returns {Promise<string | void>}
  */
 async function getPartnerCommitSha(opts) {
   const {commitSha, partnerRepoName, repoName} = opts;
@@ -378,7 +378,7 @@ async function getPartnerCommitSha(opts) {
   ).then(res => get(res, 'data.object.sha'));
 
   if (partnerCommitSha) {
-    // search in last 10 commits of partner branch
+    // search in last n commits of partner branch
     for (const index in range(historyWindow - 1)) {
       const partnerCommit = await request(
         'GET /repos/:repoName/commits/:commitSha',
@@ -404,7 +404,7 @@ async function getPartnerCommitSha(opts) {
         return partnerCommitSha;
       }
 
-      if (index < historyWindow - 2 && partnerCommit.parents.length === 1) {
+      if (index < historyWindow - 2 && partnerCommit.parents.length) {
         partnerCommitSha = partnerCommit.parents[0].sha;
       } else {
         break;
@@ -692,37 +692,19 @@ export async function getPRCommitList(pullRequest, subPath) {
             commit._ = fullCommit;
 
             if (mergedCommit && mergedCommit.files.length) {
-              let modifiesFilesInSubPath = false;
-
-              for (const file of mergedCommit.files) {
-                if (file.filename.startsWith(subPath)) {
-                  modifiesFilesInSubPath = true;
-                  break;
-                }
-              }
-
-              commit.mergedCommit.shouldSync = modifiesFilesInSubPath;
+              commit.mergedCommit.shouldSync = commitModifiesSubPath(
+                mergedCommit,
+              );
             }
 
             if (fullCommit.files.length) {
-              let modifiesFilesAboveSubPath = false;
-              let modifiesFilesInSubPath = false;
-
-              for (const file of fullCommit.files) {
-                if (file.filename.startsWith(subPath)) {
-                  modifiesFilesInSubPath = true;
-                } else {
-                  modifiesFilesAboveSubPath = true;
-                }
-
-                if (modifiesFilesAboveSubPath && modifiesFilesInSubPath) break;
-              }
+              const modifiesSubPath = commitModifiesSubPath(fullCommit);
 
               commit.shouldSync =
-                modifiesFilesInSubPath ||
+                modifiesSubPath ||
                 (commit.mergedCommit && commit.mergedCommit.shouldSync);
               commit.shouldUseGenericMessage =
-                modifiesFilesInSubPath && modifiesFilesAboveSubPath;
+                modifiesSubPath && commitModifiesAboveSubPath(fullCommit);
             }
           }
 

--- a/lib/sync/commits.test.js
+++ b/lib/sync/commits.test.js
@@ -5,13 +5,22 @@
  */
 
 import clone from 'just-clone';
+import extend from 'just-extend';
+import nock from 'nock';
+import commitFixture from '../__fixtures__/commit.json';
+import refFixture from '../__fixtures__/ref.json';
+import * as cache from '../cache.js';
 import {base64Encode} from '../utils.js';
 import {
   copyCommitTree,
   getCommitsState,
+  getPartnerRebaseSha,
   parseCommitMeta,
   stripCommitMeta,
 } from './commits.js';
+
+jest.mock('../github/utils.js');
+nock.disableNetConnect();
 
 describe('getCommitsState', () => {
   test('simple', () => {
@@ -477,5 +486,267 @@ describe('copyCommitTree', () => {
         type: 'blob',
       },
     ]);
+  });
+});
+
+describe('getPartnerRebaseSha', () => {
+  afterEach(() => {
+    nock.cleanAll();
+    cache.clear();
+  });
+
+  /*
+   * direct partner commit:
+   * syncing rebase of source:feature (a2) onto source:master (a3)
+   *
+   * source:master
+   * a1----a3
+   * source:feature (before rebase)
+   * a1-a2
+   * source:feature (after rebase)
+   * a1-a3-a2
+   *
+   * target:master
+   * b1----b3
+   * target:feature (current)
+   * b1-b2
+   * target:feature (expected)
+   * b1-b3-b2
+   */
+  test('direct partner commit (sync from parent repo)', async () => {
+    const fixtures = {
+      commits: {
+        a3: extend({}, commitFixture, {
+          sha: 'a3',
+          commit: {
+            message: 'update something',
+          },
+          files: [{filename: `foo/bar.txt`}],
+          parents: [{sha: 'a1'}],
+        }),
+        b3: extend({}, commitFixture, {
+          sha: 'b3',
+          commit: {
+            message: 'update something\n\nmeta:sha:a3',
+          },
+          files: [{filename: `bar.txt`}],
+          parents: [{sha: 'b1'}],
+        }),
+      },
+      refs: {
+        targetMaster: extend({}, refFixture, {
+          object: {
+            sha: 'b3',
+          },
+        }),
+      },
+    };
+
+    nock('https://api.github.com')
+      .get('/repos/org/source-repo/commits/a3')
+      .reply(200, fixtures.commits.a3)
+      .get('/repos/org/source-repo/commits/a3')
+      .reply(200, fixtures.commits.a3)
+      .get('/repos/org/target-repo/git/refs/heads/master')
+      .reply(200, fixtures.refs.targetMaster)
+      .get('/repos/org/target-repo/commits/b3')
+      .reply(200, fixtures.commits.b3);
+
+    expect(
+      await getPartnerRebaseSha({
+        commitSha: 'a3',
+        partnerBranch: 'master',
+        partnerRepoName: 'org/target-repo',
+        repoName: 'org/source-repo',
+        subPath: 'foo',
+      }),
+    ).toBe('b3');
+  });
+
+  test('direct partner commit (sync from child repo)', async () => {
+    const fixtures = {
+      commits: {
+        a3: extend({}, commitFixture, {
+          sha: 'a3',
+          commit: {
+            message: 'update something\n\nmeta:sha:b3',
+          },
+          files: [{filename: `bar.txt`}],
+          parents: [{sha: 'a1'}],
+        }),
+        b3: extend({}, commitFixture, {
+          sha: 'b3',
+          commit: {
+            message: 'update something',
+          },
+          files: [{filename: `foo/bar.txt`}],
+          parents: [{sha: 'b1'}],
+        }),
+      },
+    };
+
+    nock('https://api.github.com')
+      .get('/repos/org/source-repo/commits/a3')
+      .reply(200, fixtures.commits.a3)
+      .get('/repos/org/source-repo/commits/a3')
+      .reply(200, fixtures.commits.a3)
+      .get('/repos/org/target-repo/commits/b3')
+      .reply(200, fixtures.commits.b3);
+
+    expect(
+      await getPartnerRebaseSha({
+        commitSha: 'a3',
+        partnerBranch: 'master',
+        partnerRepoName: 'org/target-repo',
+        repoName: 'org/source-repo',
+      }),
+    ).toBe('b3');
+  });
+
+  /*
+   * indirect partner commit:
+   * syncing rebase of source:feature (a2) onto source:master (a4);
+   * a4 doesn't modify files in `subPath` so doesn't exist in target repo
+   *
+   * source:master
+   * a1----a3-a4
+   * source:feature (before rebase)
+   * a1-a2
+   * source:feature (after rebase)
+   * a1-a3-a4-a2
+   *
+   * target:master
+   * b1----b3
+   * target:feature (current)
+   * b1-b2
+   * target:feature (expected)
+   * b1-b3-b2
+   */
+  test('indirect partner commit', async () => {
+    const fixtures = {
+      commits: {
+        a4: extend({}, commitFixture, {
+          sha: 'a4',
+          commit: {
+            message: "update something that won't be synced",
+          },
+          files: [{filename: `baz.txt`}],
+          parents: [{sha: 'a3'}],
+        }),
+        a3: extend({}, commitFixture, {
+          sha: 'a3',
+          commit: {
+            message: 'update something',
+          },
+          files: [{filename: `foo/bar.txt`}],
+          parents: [{sha: 'a1'}],
+        }),
+        b3: extend({}, commitFixture, {
+          sha: 'b3',
+          commit: {
+            message: 'update something\n\nmeta:sha:a3',
+          },
+          files: [{filename: `bar.txt`}],
+          parents: [{sha: 'b1'}],
+        }),
+      },
+      refs: {
+        targetMaster: extend({}, refFixture, {
+          object: {
+            sha: 'b3',
+          },
+        }),
+      },
+    };
+
+    nock('https://api.github.com')
+      .get('/repos/org/source-repo/commits/a4')
+      .reply(200, fixtures.commits.a4)
+      .get('/repos/org/source-repo/commits/a3')
+      .reply(200, fixtures.commits.a3)
+      .get('/repos/org/source-repo/commits/a3')
+      .reply(200, fixtures.commits.a3)
+      .get('/repos/org/target-repo/git/refs/heads/master')
+      .reply(200, fixtures.refs.targetMaster)
+      .get('/repos/org/target-repo/commits/b3')
+      .reply(200, fixtures.commits.b3);
+
+    expect(
+      await getPartnerRebaseSha({
+        commitSha: 'a4',
+        partnerBranch: 'master',
+        partnerRepoName: 'org/target-repo',
+        repoName: 'org/source-repo',
+        subPath: 'foo',
+      }),
+    ).toBe('b3');
+  });
+
+  /*
+   * no partner commit:
+   * syncing rebase of source:feature (a2) onto source:master (ax);
+   * ax *does* modify files in subPath, but doesn't exist in target repo
+   *
+   * source:master
+   * a1----ax
+   * source:feature (before rebase)
+   * a1-a2
+   * source:feature (after rebase)
+   * a1-ax-a2
+   *
+   * target:master
+   * b1
+   * target:feature
+   * b1-b2
+   */
+  test('no partner commit', async () => {
+    const fixtures = {
+      commits: {
+        ax: extend({}, commitFixture, {
+          sha: 'ax',
+          commit: {
+            message: 'update something',
+          },
+          files: [{filename: `foo/bar.txt`}],
+          parents: [{sha: 'a1'}],
+        }),
+        b1: extend({}, commitFixture, {
+          sha: 'b1',
+          commit: {
+            message: 'init commit',
+          },
+          files: [{filename: `bar.txt`}],
+          parents: [],
+        }),
+      },
+      refs: {
+        targetMaster: extend({}, refFixture, {
+          object: {
+            sha: 'b1',
+          },
+        }),
+      },
+    };
+
+    nock('https://api.github.com')
+      .get('/repos/org/source-repo/commits/ax')
+      .reply(200, fixtures.commits.ax)
+      .get('/repos/org/source-repo/commits/ax')
+      .reply(200, fixtures.commits.ax)
+      .get('/repos/org/target-repo/git/refs/heads/master')
+      .reply(200, fixtures.refs.targetMaster)
+      .get('/repos/org/target-repo/commits/b1')
+      .reply(200, fixtures.commits.b1);
+
+    expect(
+      await getPartnerRebaseSha({
+        commitSha: 'ax',
+        fallbackSha: 'b1',
+        partnerBranch: 'master',
+        partnerRepoName: 'org/target-repo',
+        repoName: 'org/source-repo',
+        subPath: 'foo',
+      }),
+    ).toBe('b1');
   });
 });

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint": "^5.15.3",
     "eslint-plugin-prettier": "^3.0.1",
     "jest": "^24.8.0",
+    "just-extend": "^4.0.2",
     "nock": "^10.0.6",
     "nodemon": "^1.17.2",
     "prettier": "^1.16.4",
@@ -53,7 +54,8 @@
       "lib"
     ],
     "ignore": [
-      "*.test.js"
+      "*.test.js",
+      "__fixtures__"
     ]
   },
   "jest": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3784,6 +3784,11 @@ just-clone@^3.1.0:
   resolved "https://registry.yarnpkg.com/just-clone/-/just-clone-3.1.0.tgz#10efc422e9b041355c43b8076d7b768b7a09fbbd"
   integrity sha512-sROn15yHaeNYSTG49HmfbQLtsZvMBb2COvVofNXbeUXx6GkERkdjG3dfejD0fe78gdHJLyS+fOz897H73S8LqA==
 
+just-extend@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.0.2.tgz#f3f47f7dfca0f989c55410a7ebc8854b07108afc"
+  integrity sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==
+
 just-index@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/just-index/-/just-index-2.1.0.tgz#0f0e3a6f1948e1912079fd63fbad56526a769b4b"


### PR DESCRIPTION
### Before

When source repo rebases, target repo re-applies "new" (rebased) commits **on top of the existing parent commit of the pull request branch**

### After

When source repo rebases, target repo **searches for an appropriate new parent commit** to apply rebased commits on top of

---

To help read the diff:

- [Actual change](https://github.com/uber-workflow/probot-app-monorepo-sync/pull/26/commits/f25b651ecdbb16560334bedc25d54330e2dd99f2)
- [Tests](https://github.com/uber-workflow/probot-app-monorepo-sync/pull/26/commits/09ab65436cbab4a1d2d881e8b292d31a631ddb28)
- [Cleanup](https://github.com/uber-workflow/probot-app-monorepo-sync/pull/26/commits/cac5b9b5442bcf1873620ef7d25ea13ec7395f54)