### PR TITLE
Release v2.0.0-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "probot-app-usync",
-  "version": "0.0.1-0",
+  "version": "2.0.0-0",
   "description": "A Probot implementation of uSync",
   "author": "Chris Deacy <deacy@uber.com>",
   "license": "MIT",


### PR DESCRIPTION
Since this is using the same repo as `probot-app-monorepo-sync` (just renamed), can't have overlapping version tags, so will just start at 2.x