### PR TITLE
Reduce API requests made by ProbotCommands

### DIFF
--- a/lib/ProbotCommands.js
+++ b/lib/ProbotCommands.js
@@ -27,6 +27,16 @@ module.exports = class ProbotCommands {
     );
   }
 
+  _getCommentCommand(commentBody) {
+    commentBody = commentBody.replace(/\r\n|\r|\n/g, '').trim();
+
+    for (const [command] of this._commands) {
+      if (commentBody === command) {
+        return command;
+      }
+    }
+  }
+
   /**
    * @param {ProbotContextType} context
    */
@@ -36,21 +46,22 @@ module.exports = class ProbotCommands {
     const {user} = comment;
 
     if (issue.pull_request && issue.state === 'open' && user.type === 'User') {
-      const {
-        data: {permission: userPermission},
-      } = await github.request(
-        'GET /repos/:repoName/collaborators/:username/permission',
-        {
-          repoName: repository.full_name,
-          username: user.login,
-        },
-      );
+      const command = this._getCommentCommand(comment.body);
 
-      if (userPermission === 'admin' || userPermission === 'write') {
-        for (const [command, handler] of this._commands) {
-          if (comment.body.replace(/\n/g, '').trim() === command) {
-            return handler(context, command);
-          }
+      if (command) {
+        const {
+          data: {permission: userPermission},
+        } = await github.request(
+          'GET /repos/:repoName/collaborators/:username/permission',
+          {
+            repoName: repository.full_name,
+            username: user.login,
+          },
+        );
+
+        if (userPermission === 'admin' || userPermission === 'write') {
+          const handler = this._commands.get(command);
+          return handler(context, command);
         }
       }
     }

--- a/lib/ProbotCommands.test.js
+++ b/lib/ProbotCommands.test.js
@@ -54,6 +54,7 @@ function createProbot(entry) {
 
 test('Triggers commands', async () => {
   let triggerCount = 0;
+  let permissionRequestCount = 0;
   const probot = createProbot(app => {
     const commands = new ProbotCommands(app);
     commands.on('!foo', async () => triggerCount++);
@@ -62,7 +63,10 @@ test('Triggers commands', async () => {
   async function runCommandTest(permissionFixture, commentFixture) {
     nock('https://api.github.com')
       .get('/repos/org/test-repo/collaborators/test-user/permission')
-      .reply(200, permissionFixture);
+      .reply(200, () => {
+        permissionRequestCount++;
+        return permissionFixture;
+      });
     await probot.receive({
       name: 'issue_comment',
       payload: commentFixture,
@@ -70,9 +74,11 @@ test('Triggers commands', async () => {
   }
 
   // SHOULD NOT trigger
+  // SHOULD make permissions request
   await runCommandTest(fixtures.permission.read, fixtures.comment);
 
   // SHOULD NOT trigger
+  // SHOULD NOT make permissions request
   await runCommandTest(
     fixtures.permission.admin,
     extend(true, {}, fixtures.comment, {
@@ -81,6 +87,7 @@ test('Triggers commands', async () => {
   );
 
   // SHOULD NOT trigger
+  // SHOULD NOT make permissions request
   await runCommandTest(
     fixtures.permission.admin,
     extend(true, {}, fixtures.comment, {
@@ -89,9 +96,11 @@ test('Triggers commands', async () => {
   );
 
   // SHOULD trigger
+  // SHOULD make permissions request
   await runCommandTest(fixtures.permission.admin, fixtures.comment);
 
   // SHOULD trigger
+  // SHOULD make permissions request
   await runCommandTest(
     fixtures.permission.admin,
     extend({}, fixtures.comment, {
@@ -100,6 +109,9 @@ test('Triggers commands', async () => {
   );
 
   expect(triggerCount).toBe(2);
+  // should only request for permissions if the comment
+  // has a command matches and the issue is open
+  expect(permissionRequestCount).toBe(3);
 });
 
 test('Supports array of commands', async () => {

--- a/lib/ProbotCommands.test.js
+++ b/lib/ProbotCommands.test.js
@@ -109,8 +109,8 @@ test('Triggers commands', async () => {
   );
 
   expect(triggerCount).toBe(2);
-  // should only request for permissions if the comment
-  // has a command matches and the issue is open
+  // should only request for permissions if the comment has
+  // a command that matches and the issue is open
   expect(permissionRequestCount).toBe(3);
 });
 


### PR DESCRIPTION
Previously, `ProbotCommands.js` would make an API request to check for user permissions for every comment event (so almost every comment made by anyone on a pull request would trigger an unnecessary API call, considering most comments aren't commands).

This improves the logic so that it only makes the request if the comment body matches a command handler