### PR TITLE
Remove custom handling of issue keywords

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -182,30 +182,6 @@ async function closeIssue(issue) {
 }
 
 /**
- * @param {PullRequestOpt} issue
- * @returns {Promise<Boolean>}
- */
-async function issueIsOpen(issue) {
-  const {number, repoName} = issue;
-  const [owner, repo] = repoName.split('/');
-
-  try {
-    const res = await github.graphql(
-      `query($owner: String!, $repo: String!, $number: Int!) {
-        repository(owner: $owner, name: $repo) {
-          issue(number: $number) { state }
-        }
-      }`,
-      {owner, repo, number},
-    );
-
-    return get(res, 'repository.issue.state') === 'OPEN';
-  } catch (e) {
-    return false;
-  }
-}
-
-/**
  * @param {PullRequestOpt} pullRequest
  * @param {string} branchName
  * @returns {Promise<*>}
@@ -320,87 +296,6 @@ async function getFileContent(repoName, filepath) {
     .then(res => get(res, 'data.content'));
 
   return content && Buffer.from(content, 'base64').toString('utf-8');
-}
-
-/**
- * @param {string} pullRequestBody
- * @param {string} defaultRepo
- * @returns {{
- *   number: number,
- *   repoName: string,
- * }[]}
- */
-function getGithubIssueRefs(pullRequestBody, defaultRepo) {
-  // ref: https://help.github.com/en/articles/closing-issues-using-keywords
-  const keywords =
-    'close|closed|closes|fix|fixed|fixes|resolve|resolved|resolves';
-  // ref: https://help.github.com/en/articles/autolinked-references-and-urls#issues-and-pull-requests
-  const refTypes = [
-    '#',
-    '([a-z-]+/[a-z-.]+)#',
-    'GH-',
-    'https:\\/\\/github\\.com\\/([a-z-]+\\/[a-z-.]+)\\/issues\\/',
-  ].join('|');
-  const regex = new RegExp(`(?:${keywords}) (?:${refTypes})(\\d+)`, 'gi');
-  const result = [];
-  let match;
-
-  while ((match = regex.exec(pullRequestBody))) {
-    const [, repoName1, repoName2, number] = match;
-
-    result.push({
-      repoName: repoName1 || repoName2 || defaultRepo,
-      number: parseInt(number),
-    });
-  }
-
-  return result;
-}
-
-/**
- * Parses the pull request body to find referenced
- * issues (e.g. 'Fixes #000') and closes/comments on
- * any that are open and belong to the same repo as
- * the pull request
- *
- * @param {PullRequestOpt & {
- *   body?: string,
- * }} pullRequest
- * @returns {Promise<*>}
- */
-async function handleIssueKeywords(pullRequest) {
-  const {number, repoName} = pullRequest;
-  let body = pullRequest.body;
-
-  if (!Object.keys(pullRequest).includes('body')) {
-    const [owner, repo] = repoName.split('/');
-
-    body = await github
-      .graphql(
-        `query($owner: String!, $repo: String!, $number: Int!) {
-          repository(owner: $owner, name: $repo) {
-            pullRequest(number: $number) { body }
-          }
-        }`,
-        {owner, repo, number},
-      )
-      .then(res => get(res, 'repository.pullRequest.body'));
-  }
-
-  const issueRefs = getGithubIssueRefs(body).filter(
-    issue => issue.repoName === repoName,
-  );
-
-  if (issueRefs.length) {
-    await Promise.all(
-      issueRefs.map(async issue => {
-        if (await issueIsOpen(issue)) {
-          await closeIssue(issue);
-          await addComment(issue, lang.notify_issueClosed(number));
-        }
-      }),
-    );
-  }
 }
 
 /**
@@ -659,7 +554,6 @@ function ProbotApp(app) {
               pullRequest,
               lang.notify_landed(landedRepos[pullRequest.repoName].sha),
             );
-            await handleIssueKeywords(pullRequest);
 
             if (!isFork) {
               await deleteBranch(pullRequest, pullRequest.headRefName);
@@ -676,7 +570,6 @@ function ProbotApp(app) {
               importedPR,
               lang.notify_landed(landedRepos[importedPR.repoName].sha),
             );
-            await handleIssueKeywords(importedPR);
           })(),
         ]);
       }
@@ -691,6 +584,5 @@ module.exports = {
   ProbotApp,
   // exported for tests
   generateCommitMessages,
-  getGithubIssueRefs,
   trimLines,
 };

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -4,11 +4,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {
-  generateCommitMessages,
-  getGithubIssueRefs,
-  trimLines,
-} = require('./index.js');
+const {generateCommitMessages, trimLines} = require('./index.js');
 
 test('trimLines', () => {
   expect(trimLines('\n\n\nfoo\n\n')).toBe('foo');
@@ -95,25 +91,4 @@ test('generateCommitMessages', () => {
     'foo/child':
       'Some custom child title (#20)\nhttps://github.com/foo/child/pull/20\n\ncustom child summary',
   });
-});
-
-test('getGithubIssueRefs', () => {
-  expect(getGithubIssueRefs('Lorem ipsum blah blah', 'foo/repo')).toEqual([]);
-  // invalid issue ref
-  expect(getGithubIssueRefs('Fixes 1', 'foo/repo')).toEqual([]);
-  expect(
-    getGithubIssueRefs(
-      `Lorem ipsum blah blah
-
-      Fixes #1, fixes 2, resolves GH-34, Closes bar/repo#1
-
-      fix https://github.com/baz/repo/issues/100`,
-      'foo/repo',
-    ),
-  ).toEqual([
-    {number: 1, repoName: 'foo/repo'},
-    {number: 34, repoName: 'foo/repo'},
-    {number: 1, repoName: 'bar/repo'},
-    {number: 100, repoName: 'baz/repo'},
-  ]);
 });

--- a/lib/lang.js
+++ b/lib/lang.js
@@ -35,7 +35,6 @@ module.exports = {
    */
   notify_importedToParent: ({importedPR, importer}) =>
     `This pull request was imported from [${importedPR.repoName}#${importedPR.number}](${importedPR.url}) by @${importer}. Comment \`!land\` when the change is ready to be landed.`,
-  notify_issueClosed: prNumber => `This issue was closed via #${prNumber}.`,
   notify_landed: sha => `This pull request was landed via ${sha}.`,
   error_approval: command =>
     `Unable to ${command}. At least one approved review is required.`,


### PR DESCRIPTION
Turns out, Github supports `Fixes #000`, etc. keywords in commit messages as well, so this will be handled automatically as long as the special phrase ends up in the landed commit message