### PR TITLE
Fix detection of imported PR with forks

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -121,7 +121,7 @@ function ProbotApp(app) {
 
         const newBranch = [
           'imports',
-          pullRequest.headRepository.nameWithOwner,
+          pullRequest.repoName,
           payload.issue.number,
         ].join('/');
         let prTemplate;


### PR DESCRIPTION
When landing, the bot uses the branch name to determine if the PR was opened as a result of an `!import`:

https://github.com/uber-workflow/probot-app-usync/blob/5bd0cc5ddc453f3ed2c5579bca4ff20ce0e222f6/lib/index.js#L193-L203

It should have commented on [this PR](https://github.com/fusionjs/fusionjs/pull/673) when it was `!land`ed, but since the imported branch was generated using the head repository name (`imports/sagiavinash/fusionjs/673`), no follow-up comment was made on the imported PR to notify that it was landed.

---

This PR fixes this issue by using the base repo name (e.g. `fusionjs/fusionjs`) to generate the imported branch name