### PR TITLE
Fix parsing of summaries with sub-headings

### DIFF
--- a/lib/github.js
+++ b/lib/github.js
@@ -272,7 +272,7 @@ function parsePRBody(body) {
       .replace(/\r\n|\r|\n/g, '\n')
       // strip html comments
       .replace(/<!--[\s\S]*?(?:-->)/g, '')
-      .split(/^(?=## ?.+)/m)
+      .split(/^(?=## .+)/m)
       .reduce((result, section) => {
         const content = section
           .replace(/^## ?.+\n/, '')

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -114,4 +114,18 @@ test('generateCommitMessages', () => {
       'Parent PR title (#10)\nhttps://github.com/foo/parent/pull/10\n\nParent PR summary',
     'foo/child': 'Child PR title\n\n**some-bolded-thing**\nblahblah',
   });
+
+  expect(
+    generateCommitMessages({
+      repoName: 'foo/parent',
+      number: 10,
+      body:
+        '## Summary\n\nParent PR summary\n\n### Sub-heading\n\nfoo\n\n## Commit message overrides\n\n**foo/child**',
+      title: 'Parent PR title',
+    }),
+  ).toEqual({
+    generic: 'Parent PR title\n\nParent PR summary\n\n### Sub-heading\n\nfoo',
+    'foo/parent':
+      'Parent PR title (#10)\nhttps://github.com/foo/parent/pull/10\n\nParent PR summary\n\n### Sub-heading\n\nfoo',
+  });
 });


### PR DESCRIPTION
Prevents the parser from eating sub-headings (`###` and below) from summaries. [This commit](https://github.com/fusionjs/fusionjs/commit/0b548f9be304ab6eeb166ba8dcac7e416b09c5ba) was landed from a PR with sub-headings, but the message was cut off before the first sub-heading