### PR TITLE
Update release PR commit message

### DIFF
--- a/lib/github.js
+++ b/lib/github.js
@@ -344,10 +344,13 @@ async function prHasLabel(pullRequest, label) {
  * @returns {Promise<void>}
  */
 async function mergeReleasePR(pullRequest) {
+  const {number, repoName, title, url} = pullRequest;
   return github.request('PUT /repos/:repoName/pulls/:number/merge', {
-    ...pick(pullRequest, ['repoName', 'number']),
+    number,
+    repoName,
     data: {
-      commit_title: pullRequest.title,
+      commit_title: `${title} (#${number})`,
+      commit_message: url,
       merge_method: 'squash',
     },
   });


### PR DESCRIPTION
Currently it uses github's default message, which just spits out a list of the commits in the PR. This updates it to just match the format of the other commits:

```
PR title (#000)
https://github.com/org/repo/pull/000
```